### PR TITLE
Reduce the dependency footprint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,11 +158,6 @@
 		
 		<!-- Additional dependencies -->
 		<dependency>
-			<groupId>com.google.guava</groupId>
-			<artifactId>guava</artifactId>
-		</dependency>
-		
-		<dependency>
 			<groupId>org.smurn</groupId>
 			<artifactId>jply</artifactId>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -134,12 +134,6 @@
 	</repositories>
 
 	<dependencies>
-		<!-- SciJava dependencies -->
-		<dependency>
-			<groupId>org.scijava</groupId>
-			<artifactId>scijava-common</artifactId>
-		</dependency>
-
 		<!-- ImgLib2 dependencies -->
 		<dependency>
 			<groupId>net.imglib2</groupId>

--- a/src/main/java/net/imglib2/mesh/impl/naive/NaiveDoubleMesh.java
+++ b/src/main/java/net/imglib2/mesh/impl/naive/NaiveDoubleMesh.java
@@ -29,9 +29,8 @@
 
 package net.imglib2.mesh.impl.naive;
 
-import org.scijava.util.DoubleArray;
-import org.scijava.util.IntArray;
-
+import gnu.trove.list.array.TDoubleArrayList;
+import gnu.trove.list.array.TIntArrayList;
 import net.imglib2.mesh.Mesh;
 
 public class NaiveDoubleMesh implements Mesh
@@ -64,22 +63,22 @@ public class NaiveDoubleMesh implements Mesh
 	public class Vertices implements net.imglib2.mesh.Vertices
 	{
 
-		private final DoubleArray xs, ys, zs;
+		private final TDoubleArrayList xs, ys, zs;
 
-		private final DoubleArray nxs, nys, nzs;
+		private final TDoubleArrayList nxs, nys, nzs;
 
-		private final DoubleArray us, vs;
+		private final TDoubleArrayList us, vs;
 
 		public Vertices()
 		{
-			xs = new DoubleArray();
-			ys = new DoubleArray();
-			zs = new DoubleArray();
-			nxs = new DoubleArray();
-			nys = new DoubleArray();
-			nzs = new DoubleArray();
-			us = new DoubleArray();
-			vs = new DoubleArray();
+			xs = new TDoubleArrayList();
+			ys = new TDoubleArrayList();
+			zs = new TDoubleArrayList();
+			nxs = new TDoubleArrayList();
+			nys = new TDoubleArrayList();
+			nzs = new TDoubleArrayList();
+			us = new TDoubleArrayList();
+			vs = new TDoubleArrayList();
 		}
 
 		@Override
@@ -295,18 +294,18 @@ public class NaiveDoubleMesh implements Mesh
 	public class Triangles implements net.imglib2.mesh.Triangles
 	{
 
-		private final IntArray v0s, v1s, v2s;
+		private final TIntArrayList v0s, v1s, v2s;
 
-		private final DoubleArray nxs, nys, nzs;
+		private final TDoubleArrayList nxs, nys, nzs;
 
 		public Triangles()
 		{
-			v0s = new IntArray();
-			v1s = new IntArray();
-			v2s = new IntArray();
-			nxs = new DoubleArray();
-			nys = new DoubleArray();
-			nzs = new DoubleArray();
+			v0s = new TIntArrayList();
+			v1s = new TIntArrayList();
+			v2s = new TIntArrayList();
+			nxs = new TDoubleArrayList();
+			nys = new TDoubleArrayList();
+			nzs = new TDoubleArrayList();
 		}
 
 		@Override

--- a/src/main/java/net/imglib2/mesh/impl/naive/NaiveFloatMesh.java
+++ b/src/main/java/net/imglib2/mesh/impl/naive/NaiveFloatMesh.java
@@ -29,9 +29,8 @@
 
 package net.imglib2.mesh.impl.naive;
 
-import org.scijava.util.FloatArray;
-import org.scijava.util.IntArray;
-
+import gnu.trove.list.array.TFloatArrayList;
+import gnu.trove.list.array.TIntArrayList;
 import net.imglib2.mesh.Mesh;
 
 public class NaiveFloatMesh implements Mesh
@@ -64,22 +63,22 @@ public class NaiveFloatMesh implements Mesh
 	public class Vertices implements net.imglib2.mesh.Vertices
 	{
 
-		private final FloatArray xs, ys, zs;
+		private final TFloatArrayList xs, ys, zs;
 
-		private final FloatArray nxs, nys, nzs;
+		private final TFloatArrayList nxs, nys, nzs;
 
-		private final FloatArray us, vs;
+		private final TFloatArrayList us, vs;
 
 		public Vertices()
 		{
-			xs = new FloatArray();
-			ys = new FloatArray();
-			zs = new FloatArray();
-			nxs = new FloatArray();
-			nys = new FloatArray();
-			nzs = new FloatArray();
-			us = new FloatArray();
-			vs = new FloatArray();
+			xs = new TFloatArrayList();
+			ys = new TFloatArrayList();
+			zs = new TFloatArrayList();
+			nxs = new TFloatArrayList();
+			nys = new TFloatArrayList();
+			nzs = new TFloatArrayList();
+			us = new TFloatArrayList();
+			vs = new TFloatArrayList();
 		}
 
 		@Override
@@ -213,18 +212,18 @@ public class NaiveFloatMesh implements Mesh
 	public class Triangles implements net.imglib2.mesh.Triangles
 	{
 
-		private final IntArray v0s, v1s, v2s;
+		private final TIntArrayList v0s, v1s, v2s;
 
-		private final FloatArray nxs, nys, nzs;
+		private final TFloatArrayList nxs, nys, nzs;
 
 		public Triangles()
 		{
-			v0s = new IntArray();
-			v1s = new IntArray();
-			v2s = new IntArray();
-			nxs = new FloatArray();
-			nys = new FloatArray();
-			nzs = new FloatArray();
+			v0s = new TIntArrayList();
+			v1s = new TIntArrayList();
+			v2s = new TIntArrayList();
+			nxs = new TFloatArrayList();
+			nys = new TFloatArrayList();
+			nzs = new TFloatArrayList();
 		}
 
 		@Override

--- a/src/main/java/net/imglib2/mesh/io/ply/PLYMeshIO.java
+++ b/src/main/java/net/imglib2/mesh/io/ply/PLYMeshIO.java
@@ -32,6 +32,7 @@ package net.imglib2.mesh.io.ply;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;
@@ -41,7 +42,6 @@ import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.scijava.util.FileUtils;
 import org.smurn.jply.Element;
 import org.smurn.jply.ElementReader;
 import org.smurn.jply.PlyReader;
@@ -88,7 +88,10 @@ public final class PLYMeshIO
 	public static final void save( final Mesh data, final String destination ) throws IOException
 	{
 		final byte[] bytes = writeBinary( data );
-		FileUtils.writeFile( new File( destination ), bytes );
+		try ( FileOutputStream fos = new FileOutputStream( destination ) )
+		{
+			fos.write( bytes );
+		}
 	}
 
 	public static final void read( final File plyFile, final Mesh mesh ) throws IOException

--- a/src/main/java/net/imglib2/mesh/io/stl/STLMeshIO.java
+++ b/src/main/java/net/imglib2/mesh/io/stl/STLMeshIO.java
@@ -38,8 +38,6 @@ import java.nio.file.Paths;
 
 import org.scijava.util.FileUtils;
 
-import com.google.common.base.Strings;
-
 import net.imglib2.mesh.Mesh;
 import net.imglib2.mesh.Triangle;
 import net.imglib2.mesh.impl.naive.NaiveFloatMesh;
@@ -60,7 +58,8 @@ public final class STLMeshIO
 
 	public static final int HEADER_BYTES = 80;
 
-	public static final String HEADER = Strings.padEnd( "Binary STL created with ImageJ", HEADER_BYTES, '.' );
+
+	public static final String HEADER = padEnd( "Binary STL created with ImageJ", HEADER_BYTES, '.' );
 
 	public static final int COUNT_BYTES = 4;
 
@@ -82,8 +81,7 @@ public final class STLMeshIO
 			return;
 
 		buffer.position( FACET_START );
-		for ( int offset = FACET_START; offset < buffer.capacity(); offset +=
-				FACET_BYTES )
+		for ( int offset = FACET_START; offset < buffer.capacity(); offset += FACET_BYTES )
 		{
 			readFacet( mesh, buffer );
 		}
@@ -176,5 +174,13 @@ public final class STLMeshIO
 				v1x, v1y, v1z, //
 				v2x, v2y, v2z, //
 				nx, ny, nz );
+	}
+
+	private static String padEnd( final String s, final int minLen, final char padChar )
+	{
+		final StringBuilder sb = new StringBuilder();
+		while ( sb.length() < minLen )
+			sb.append(padChar);
+		return sb.toString();
 	}
 }

--- a/src/main/java/net/imglib2/mesh/io/stl/STLMeshIO.java
+++ b/src/main/java/net/imglib2/mesh/io/stl/STLMeshIO.java
@@ -30,13 +30,12 @@
 package net.imglib2.mesh.io.stl;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-
-import org.scijava.util.FileUtils;
 
 import net.imglib2.mesh.Mesh;
 import net.imglib2.mesh.Triangle;
@@ -130,7 +129,10 @@ public final class STLMeshIO
 	public static final void save( final Mesh data, final String destination ) throws IOException
 	{
 		final byte[] bytes = write( data );
-		FileUtils.writeFile( new File( destination ), bytes );
+		try ( FileOutputStream fos = new FileOutputStream( destination ) )
+		{
+			fos.write( bytes );
+		}
 	}
 
 	// -- Helper methods --

--- a/src/main/java/net/imglib2/mesh/io/xyz/XYZPointsIO.java
+++ b/src/main/java/net/imglib2/mesh/io/xyz/XYZPointsIO.java
@@ -35,9 +35,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.scijava.log.LogService;
-import org.scijava.log.StderrLogService;
-
 import net.imglib2.RealLocalizable;
 import net.imglib2.RealPoint;
 
@@ -56,11 +53,6 @@ public final class XYZPointsIO
 
 	public static final List< RealLocalizable > open( final String source ) throws IOException
 	{
-		return open( source, new StderrLogService() );
-	}
-
-	public static final List< RealLocalizable > open( final String source, final LogService log ) throws IOException
-	{
 		final ArrayList< RealLocalizable > points = new ArrayList<>();
 
 		try (final BufferedReader br = new BufferedReader( new FileReader( source ) ))
@@ -73,7 +65,7 @@ public final class XYZPointsIO
 				final String[] parts = line.trim().split( "[\\s,]+" );
 				if ( parts.length < 3 )
 				{
-					log.warn( "Invalid line: " + line );
+					//log.warn( "Invalid line: " + line );
 					continue;
 				}
 				final double x, y, z;
@@ -85,7 +77,7 @@ public final class XYZPointsIO
 				}
 				catch ( final NumberFormatException e )
 				{
-					log.warn( "Invalid line: " + line );
+					//log.warn( "Invalid line: " + line );
 					continue;
 				}
 				points.add( new RealPoint( x, y, z ) );

--- a/src/test/java/net/imglib2/mesh/MeshesTest.java
+++ b/src/test/java/net/imglib2/mesh/MeshesTest.java
@@ -40,9 +40,9 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import gnu.trove.list.array.TLongArrayList;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 import org.junit.Test;
-import org.scijava.util.LongArray;
 
 import io.scif.img.IO;
 import net.imglib2.Point;
@@ -182,7 +182,7 @@ public class MeshesTest
 		final Mesh m = new NaiveDoubleMesh();
 		// To prevent duplicates, map each (x, y, z) triple to its own index.
 		final Map< Vector3D, Long > indexMap = new HashMap<>();
-		final LongArray indices = new LongArray();
+		final TLongArrayList indices = new TLongArrayList();
 		try
 		{
 			Files.lines( Paths.get( MeshesTest.class.getResource( "3d_geometric_features_mesh.txt" ).toURI() ) )

--- a/src/test/java/net/imglib2/mesh/alg/MeshCursorTest.java
+++ b/src/test/java/net/imglib2/mesh/alg/MeshCursorTest.java
@@ -59,8 +59,8 @@ public class MeshCursorTest
 	{
 		// Make an image of a cube.
 		final int expected = 100;
-		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 256, 256, 64 );
-		final FinalInterval cube = FinalInterval.createMinMax( 50, 50, 20, 150, 150, 40 );
+		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 128, 128, 64 );
+		final FinalInterval cube = FinalInterval.createMinMax( 50, 50, 20, 90, 90, 40 );
 		Views.interval( img, cube ).forEach( p -> p.set( ( byte ) expected ) );
 		test( img, expected );
 
@@ -70,7 +70,7 @@ public class MeshCursorTest
 	public void testSmallCube()
 	{
 		final int expected = 100;
-		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 256, 256, 64 );
+		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 128, 128, 64 );
 		final FinalInterval cube = FinalInterval.createMinMax( 50, 50, 20, 52, 52, 22 );
 		Views.interval( img, cube ).forEach( p -> p.set( ( byte ) expected ) );
 		test( img, expected );
@@ -81,10 +81,10 @@ public class MeshCursorTest
 	{
 		// Cube with a hole inside.
 		final int expected = 100;
-		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 256, 256, 64 );
-		final FinalInterval cube = FinalInterval.createMinMax( 50, 50, 20, 150, 150, 40 );
+		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 128, 128, 64 );
+		final FinalInterval cube = FinalInterval.createMinMax( 50, 50, 20, 90, 90, 40 );
 		Views.interval( img, cube ).forEach( p -> p.set( ( byte ) expected ) );
-		final FinalInterval hole = FinalInterval.createMinMax( 80, 80, 25, 120, 120, 35 );
+		final FinalInterval hole = FinalInterval.createMinMax( 60, 60, 25, 70, 70, 35 );
 		Views.interval( img, hole ).forEach( p -> p.set( ( byte ) 0 ) );
 		test( img, expected );
 	}
@@ -93,9 +93,9 @@ public class MeshCursorTest
 	public void testSphere()
 	{
 		final int expected = 100;
-		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 256, 256, 64 );
+		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 128, 128, 64 );
 
-		final WritableEllipsoid sphere = GeomMasks.closedEllipsoid( new double[] { 128, 128, 32 },
+		final WritableEllipsoid sphere = GeomMasks.closedEllipsoid( new double[] { 96, 96, 32 },
 				new double[] { 20, 20, 20 } );
 		Regions.sample( sphere, img ).forEach( p -> p.set( ( byte ) expected ) );
 		test( img, expected );
@@ -105,12 +105,12 @@ public class MeshCursorTest
 	public void testHollowSphere()
 	{
 		final int expected = 100;
-		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 256, 256, 64 );
+		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 128, 128, 64 );
 
-		final WritableEllipsoid sphere = GeomMasks.closedEllipsoid( new double[] { 128, 128, 32 },
+		final WritableEllipsoid sphere = GeomMasks.closedEllipsoid( new double[] { 96, 96, 32 },
 				new double[] { 20, 20, 20 } );
 		Regions.sample( sphere, img ).forEach( p -> p.set( ( byte ) expected ) );
-		final WritableEllipsoid hole = GeomMasks.closedEllipsoid( new double[] { 128, 128, 32 },
+		final WritableEllipsoid hole = GeomMasks.closedEllipsoid( new double[] { 96, 96, 32 },
 				new double[] { 10, 10, 10 } );
 		Regions.sample( hole, img ).forEach( p -> p.set( ( byte ) 0 ) );
 
@@ -121,9 +121,9 @@ public class MeshCursorTest
 	public void testEllipsoid()
 	{
 		final int expected = 100;
-		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 256, 256, 64 );
+		final Img< UnsignedByteType > img = ArrayImgs.unsignedBytes( 128, 128, 64 );
 
-		final WritableEllipsoid sphere = GeomMasks.closedEllipsoid( new double[] { 128, 128, 32 },
+		final WritableEllipsoid sphere = GeomMasks.closedEllipsoid( new double[] { 96, 96, 32 },
 				new double[] { 50, 50, 10 } );
 		Regions.sample( sphere, img ).forEach( p -> p.set( ( byte ) expected ) );
 		test( img, expected );


### PR DESCRIPTION
This patchset purges the Guava and SciJava Common dependencies.

I also attempted to remove the Apache Commons Math dependency by forking the Vector3D code, but some algorithms including `EllipsoidFitter` and `InertiaTensor` also use it for matrices and other linear algebra functions from the `org.apache.commons.math3.linear` package. So for the time being, we'll continue to live with it.

Closes #4.
