### PR TITLE
Opify static methods

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'zulu'
           cache: 'maven'
       - name: Set up CI environment

--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
-          java-version: '8'
+          java-version: '11'
           distribution: 'zulu'
           cache: 'maven'
       - name: Set up CI environment

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,11 @@
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
+			<artifactId>imglib2-algorithm</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2-roi</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,22 @@
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
 		<imageio-tiff.version>3.9.4</imageio-tiff.version>
+
+		<!--
+		NB: Older versions of OpenJDK 11 have a bug in the javadoc tool,
+		which causes errors like:
+
+		[ERROR] javadoc: error - The code being documented uses packages
+		in the unnamed module, but the packages defined in
+		https://github.com/scijava/scijava/apidocs/ are in named modules.
+
+		The most recent version of OpenJDK 11 known to have this problem
+		is 11.0.8; the oldest version known to have fixed it is 11.0.17.
+		Therefore, we set the minimum build JDK version to 11.0.17 here.
+		-->
+		<scijava.jvm.build.version>[11.0.17,)</scijava.jvm.build.version>
+		<scijava.jvm.version>8</scijava.jvm.version>
+		<scijava.ops.parse>true</scijava.ops.parse>
 	</properties>
 
 	<repositories>
@@ -130,6 +146,28 @@
 			<url>https://maven.scijava.org/content/groups/public</url>
 		</repository>
 	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<configuration>
+					<annotationProcessorPaths>
+						<path>
+							<groupId>org.scijava</groupId>
+							<artifactId>scijava-ops-indexer</artifactId>
+							<version>1.0.0</version>
+						</path>
+					</annotationProcessorPaths>
+					<fork>true</fork>
+					<compilerArgs>
+						<arg>-Ascijava.ops.parse=${scijava.ops.parse}</arg>
+						<arg>-Ascijava.ops.opVersion=${project.version}</arg>
+					</compilerArgs>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 
 	<dependencies>
 		<!-- ImgLib2 dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,18 @@
 					</compilerArgs>
 				</configuration>
 			</plugin>
+			<plugin>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<configuration>
+					<tags>
+						<tag>
+							<name>implNote</name>
+							<placement>a</placement>
+							<head>Implementation Note:</head>
+						</tag>
+					</tags>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/src/main/java/net/imglib2/mesh/MeshStats.java
+++ b/src/main/java/net/imglib2/mesh/MeshStats.java
@@ -29,7 +29,6 @@
 package net.imglib2.mesh;
 
 import net.imglib2.mesh.alg.InertiaTensor;
-import net.imglib2.type.numeric.real.DoubleType;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import net.imglib2.RealPoint;
@@ -37,7 +36,11 @@ import net.imglib2.mesh.alg.hull.ConvexHull;
 import net.imglib2.mesh.util.MeshUtil;
 import org.apache.commons.math3.linear.BlockRealMatrix;
 import org.apache.commons.math3.linear.EigenDecomposition;
+import org.apache.commons.math3.linear.MatrixUtils;
 import org.apache.commons.math3.linear.RealMatrix;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Static utilities that compute various shape descriptors of a mesh.
@@ -48,6 +51,7 @@ public class MeshStats
 	/**
 	 * Computes the volume of the specified mesh.
 	 *
+	 * @param mesh the input {@link Mesh}
 	 * @return the volume in physical units.
 	 * @implNote op names='geom.size', label='Geometric (3D): Volume',
 	 *           priority='9999.'
@@ -282,7 +286,7 @@ public class MeshStats
 	 * @param input
 	 *            the input mesh.
 	 * @return the centroid of the mesh.
-	 * @implNote op names='geom.centerOfGravity', priority='10000.'
+	 * @implNote op names='geom.centroid', priority='10000.'
 	 */
 	public static RealPoint centroid( final Mesh input )
 	{
@@ -433,8 +437,11 @@ public class MeshStats
 
 
 	/**
-	 * Describes the spareness of {@code geom.spareness}. Based on ImageJ.
+	 * Describes the spareness of a {@link Mesh}. Spareness is defined as the ratio of the {@code Mesh}'s volume to that of a best-fit ellipsoid.
+	 * Inspiration drawn from ImageJ.
 	 *
+	 * @param input the input {@link Mesh}
+	 * @return the ellipse variance
 	 * @author Tim-Oliver Buchholz (University of Konstanz)
 	 * @implNote op names='geom.spareness', label='Geometric (3D): Spareness',
 	 *           priority='10000.'

--- a/src/main/java/net/imglib2/mesh/MeshStats.java
+++ b/src/main/java/net/imglib2/mesh/MeshStats.java
@@ -28,11 +28,14 @@
  */
 package net.imglib2.mesh;
 
+import net.imglib2.mesh.alg.InertiaTensor;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
 import net.imglib2.RealPoint;
 import net.imglib2.mesh.alg.hull.ConvexHull;
 import net.imglib2.mesh.util.MeshUtil;
+import org.apache.commons.math3.linear.EigenDecomposition;
+import org.apache.commons.math3.linear.RealMatrix;
 
 /**
  * Static utilities that compute various shape descriptors of a mesh.
@@ -44,6 +47,8 @@ public class MeshStats
 	 * Computes the volume of the specified mesh.
 	 *
 	 * @return the volume in physical units.
+	 * @implNote op names='geom.size', label='Geometric (2D): Size',
+	 *           priority='9999.'
 	 */
 	public static double volume( final Mesh mesh )
 	{
@@ -88,6 +93,8 @@ public class MeshStats
 	 *            the input mesh.
 	 * @return the mesh surface area.
 	 * @author Tim-Oliver Buchholz (University of Konstanz)
+	 * @implNote op names='geom.boundarySize', label='Geometric (3D): Surface Area',
+	 *           priority='10000.'
 	 */
 	public static double surfaceArea( final Mesh mesh )
 	{
@@ -115,6 +122,8 @@ public class MeshStats
 	 * @param mesh
 	 *            the input mesh.
 	 * @return the mesh solidity value.
+	 * @implNote op names='geom.solidity', label='Geometric (3D): Solidity',
+	 *           priority='10000.'
 	 */
 	public static double solidity( final Mesh mesh )
 	{
@@ -133,6 +142,8 @@ public class MeshStats
 	 * @param convexHull
 	 *            the convex hull of the input, if it has been pre-calculated.
 	 * @return the mesh solidity value.
+	 * @implNote op names='geom.solidity', label='Geometric (3D): Solidity',
+	 *           priority='10000.'
 	 */
 	public static double solidity( final Mesh mesh, final Mesh convexHull )
 	{
@@ -151,6 +162,8 @@ public class MeshStats
 	 * @param mesh
 	 *            the input mesh.
 	 * @return the mesh convexity value.
+	 * @implNote op names='geom.convexity', label='Geometric (3D): Convexity',
+	 *           priority='10000.'
 	 */
 	public static double convexity( final Mesh mesh )
 	{
@@ -169,6 +182,8 @@ public class MeshStats
 	 * @param convexHull
 	 *            the convex hull of the input, if it has been pre-calculated.
 	 * @return the mesh convexity value.
+	 * @implNote op names='geom.convexity', label='Geometric (3D): Convexity',
+	 *           priority='10000.'
 	 */
 	public static double convexity( final Mesh mesh, final Mesh convexHull )
 	{
@@ -188,6 +203,8 @@ public class MeshStats
 	 * @param mesh
 	 *            the input mesh.
 	 * @return the mesh sphericity value.
+	 * @implNote op names='geom.sphericity', label='Geometric (3D): Sphericity',
+	 *           priority='10000.'
 	 */
 	public static double sphericity( final Mesh mesh )
 	{
@@ -214,6 +231,8 @@ public class MeshStats
 	 *            the input mesh.
 	 * @return the mesh compactness value.
 	 * @author Tim-Oliver Buchholz (University of Konstanz)
+	 * @implNote op names='geom.compactness', label='Geometric (3D): Compactness',
+	 *           priority='10000.'
 	 */
 	public static double compactness( final Mesh mesh )
 	{
@@ -237,6 +256,7 @@ public class MeshStats
 	 * @param input
 	 *            the input mesh.
 	 * @return the centroid of the mesh.
+	 * @implNote op names='geom.centroid', priority='10000.'
 	 */
 	public static RealPoint centroid( final Mesh input )
 	{

--- a/src/main/java/net/imglib2/mesh/Meshes.java
+++ b/src/main/java/net/imglib2/mesh/Meshes.java
@@ -152,7 +152,8 @@ public class Meshes
 	 * @param src
 	 *            Source mesh, from which data will be copied.
 	 * @param dest
-	 *            Destination mesh, into which source will be copied.
+	 *            Destination mesh, into which source will be copied. (container)
+	 * @implNote op names="engine.copy, copy.mesh"
 	 */
 	public static void copy( final net.imglib2.mesh.Mesh src, final net.imglib2.mesh.Mesh dest )
 	{

--- a/src/main/java/net/imglib2/mesh/Meshes.java
+++ b/src/main/java/net/imglib2/mesh/Meshes.java
@@ -75,7 +75,7 @@ public class Meshes
 	/**
 	 * Computes and returns an <b>oriented</b> bounding box {@link RealInterval}
 	 *
-	 * @param input
+	 * @param mesh
 	 * @return the output {@link Mesh}
 	 * @implNote op names="geom.boundingBox"
 	 */
@@ -101,6 +101,49 @@ public class Meshes
 				boundingBox[ 5 ] = z;
 		}
 		return Intervals.createMinMaxReal( boundingBox[ 0 ], boundingBox[ 1 ], boundingBox[ 2 ], boundingBox[ 3 ], boundingBox[ 4 ], boundingBox[ 5 ] );
+	}
+
+	/**
+	 * Computes and returns an <b>oriented</b> bounding box {@link Mesh}
+	 *
+	 * @param input
+	 * @return the output {@link Mesh}
+	 * @implNote op names="geom.boundingBox"
+	 */
+	public static Mesh boundingBoxMesh(final Mesh input) {
+		RealInterval interval = boundingBox(input);
+		Mesh m = new NaiveDoubleMesh();
+		// BOTTOM VERTICES
+		long bbl = m.vertices().add(interval.realMin(0), interval.realMin(1), interval.realMin(2));
+		long bbr = m.vertices().add(interval.realMax(0), interval.realMin(1), interval.realMin(2));
+		long bfl = m.vertices().add(interval.realMin(0), interval.realMax(1), interval.realMin(2));
+		long bfr = m.vertices().add(interval.realMax(0), interval.realMax(1), interval.realMin(2));
+		// TOP VERTICES
+		long tbl = m.vertices().add(interval.realMin(0), interval.realMin(1), interval.realMax(2));
+		long tbr = m.vertices().add(interval.realMax(0), interval.realMin(1), interval.realMax(2));
+		long tfl = m.vertices().add(interval.realMin(0), interval.realMax(1), interval.realMax(2));
+		long tfr = m.vertices().add(interval.realMax(0), interval.realMax(1), interval.realMax(2));
+
+		// BOTTOM TRIANGLES
+		m.triangles().add(bbl, bfr, bbr);
+		m.triangles().add(bbl, bfl, bfr);
+		// FRONT TRIANGLES
+		m.triangles().add(tfl, bfr, bfl);
+		m.triangles().add(tfl, tfr, bfr);
+		// TOP TRIANGLES
+		m.triangles().add(tbl, tfr, tfl);
+		m.triangles().add(tbl, tbr, tfr);
+		// BACK TRIANGLES
+		m.triangles().add(tbl, bbl, bbr);
+		m.triangles().add(tbl, tbr, tfr);
+		// LEFT TRIANGLES
+		m.triangles().add(tfl, bfl, bbl);
+		m.triangles().add(tfl, bbl, tbr);
+		// RIGHT TRIANGLES
+		m.triangles().add(tfr, tbr, bbr);
+		m.triangles().add(tfr, bbr, tfr);
+
+		return m;
 	}
 
 	/**

--- a/src/main/java/net/imglib2/mesh/Meshes.java
+++ b/src/main/java/net/imglib2/mesh/Meshes.java
@@ -40,6 +40,7 @@ import net.imglib2.mesh.alg.MarchingCubesRealType;
 import net.imglib2.mesh.alg.MeshConnectedComponents;
 import net.imglib2.mesh.alg.RemoveDuplicateVertices;
 import net.imglib2.mesh.alg.SimplifyMesh;
+import net.imglib2.mesh.impl.naive.NaiveDoubleMesh;
 import net.imglib2.mesh.impl.nio.BufferMesh;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.numeric.RealType;
@@ -71,6 +72,13 @@ public class Meshes
 		return p;
 	}
 
+	/**
+	 * Computes and returns an <b>oriented</b> bounding box {@link RealInterval}
+	 *
+	 * @param input
+	 * @return the output {@link Mesh}
+	 * @implNote op names="geom.boundingBox"
+	 */
 	public static RealInterval boundingBox( final net.imglib2.mesh.Mesh mesh )
 	{
 		final double[] boundingBox = new double[] { Double.POSITIVE_INFINITY,

--- a/src/main/java/net/imglib2/mesh/alg/InertiaTensor.java
+++ b/src/main/java/net/imglib2/mesh/alg/InertiaTensor.java
@@ -53,6 +53,9 @@ import net.imglib2.mesh.Triangle;
 public class InertiaTensor
 {
 
+	/**
+	 * @implNote op names='geom.secondMoment'
+	 */
 	public static RealMatrix calculate( final Mesh input )
 	{
 		final RealLocalizable cent = MeshStats.centroid( input );

--- a/src/main/java/net/imglib2/mesh/alg/InertiaTensor.java
+++ b/src/main/java/net/imglib2/mesh/alg/InertiaTensor.java
@@ -28,6 +28,7 @@
  */
 package net.imglib2.mesh.alg;
 
+import net.imglib2.mesh.Meshes;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 import org.apache.commons.math3.linear.BlockRealMatrix;
 import org.apache.commons.math3.linear.RealMatrix;
@@ -54,11 +55,14 @@ public class InertiaTensor
 {
 
 	/**
+	 * Computes the inertia tensor.
+	 * @param input the input {@link Mesh}
+	 * @return a {@link RealMatrix} whose entries form the inertia tensor
 	 * @implNote op names='geom.secondMoment'
 	 */
 	public static RealMatrix calculate( final Mesh input )
 	{
-		final RealLocalizable cent = MeshStats.centroid( input );
+		final RealLocalizable cent = MeshStats.centroid(input);
 		final double originX = cent.getDoublePosition( 0 );
 		final double originY = cent.getDoublePosition( 1 );
 		final double originZ = cent.getDoublePosition( 2 );

--- a/src/main/java/net/imglib2/mesh/alg/MarchingCubesBooleanType.java
+++ b/src/main/java/net/imglib2/mesh/alg/MarchingCubesBooleanType.java
@@ -104,6 +104,14 @@ public class MarchingCubesBooleanType
 		return ( byte ) ( unsignedByte & 0xff );
 	}
 
+	/**
+	 * Generates a {@link Mesh} surface from a {@link RandomAccessibleInterval}, containing all points with data value {@code true}
+	 *
+	 * @param input the input {@link RandomAccessibleInterval}
+	 * @return a {@link Mesh} describing a surface within {@code input} of all {@code true} points.
+	 * @param <T> the element type of {@code input}
+	 * @implNote op names="geom.marchingCubes", priority="100."
+	 */
 	public static < T extends BooleanType< T > > Mesh calculate( final RandomAccessibleInterval< T > input )
 	{
 		final double[][] vertlist = new double[ 12 ][];

--- a/src/main/java/net/imglib2/mesh/alg/MarchingCubesRealType.java
+++ b/src/main/java/net/imglib2/mesh/alg/MarchingCubesRealType.java
@@ -47,6 +47,7 @@ import net.imglib2.view.Views;
  *
  * @author Tim-Oliver Buchholz (University of Konstanz)
  * @author Tobias Pietzsch
+ *
  */
 public class MarchingCubesRealType
 {
@@ -106,6 +107,15 @@ public class MarchingCubesRealType
 		return ( byte ) ( unsignedByte & 0xff );
 	}
 
+	/**
+	 * Generates a {@link Mesh} surface from a {@link RandomAccessibleInterval}, containing all points with data value {@code isolevel}
+	 *
+	 * @param input the input {@link RandomAccessibleInterval}
+	 * @param isoLevel the value such that all locations on the output surface
+	 * @return a {@link Mesh} containing the isosurface within {@code input} corresponding to {@code isolevel}
+	 * @param <T> the element type of {@code input}
+	 * @implNote op names="geom.marchingCubes"
+	 */
 	public static < T extends RealType< T > > Mesh calculate( final RandomAccessibleInterval< T > input, final double isoLevel )
 	{
 		final double[][] vertlist = new double[ 12 ][ 3 ];

--- a/src/main/java/net/imglib2/mesh/alg/Voxelization.java
+++ b/src/main/java/net/imglib2/mesh/alg/Voxelization.java
@@ -28,18 +28,13 @@
  */
 package net.imglib2.mesh.alg;
 
-import net.imglib2.FinalDimensions;
-import net.imglib2.RandomAccess;
-import net.imglib2.RandomAccessibleInterval;
-import net.imglib2.RealLocalizable;
-import net.imglib2.RealPoint;
+import net.imglib2.*;
 import net.imglib2.img.Img;
 import net.imglib2.mesh.Mesh;
 import net.imglib2.mesh.Triangle;
 import net.imglib2.mesh.Vertices;
 import net.imglib2.type.BooleanType;
 import net.imglib2.type.logic.BitType;
-
 import net.imglib2.util.Util;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
 
@@ -62,13 +57,43 @@ public final class Voxelization
 		// NB: Prevent instantiation of utility class.
 	}
 
+	/**
+	 * Voxelizes {@code mesh}
+	 *
+	 * @param mesh the input {@link Mesh}
+	 * @param width the width of the resulting image
+	 * @param height the height of the resulting image
+	 * @param depth the depth of the resulting image
+	 * @return an {@link Img} containing a voxelization of {@code mesh}
+	 * @implNote op names="geom.voxelization"
+	 */
 	public static Img< BitType > voxelize( Mesh mesh, int width, int height, int depth )
 	{
-		Img< BitType > outImg = Util.getSuitableImgFactory( new FinalDimensions( width, height, depth ), new BitType() ).create( width, height, depth );
+		return voxelize(mesh, new FinalDimensions(width, height, depth));
+	}
+
+	/**
+	 * Voxelizes {@code mesh}
+	 *
+	 * @param mesh the input {@link Mesh}
+	 * @param dims the {@link Dimensions} of the output image
+	 * @return an {@link Img} containing a voxelization of {@code mesh}
+	 * @implNote op names="geom.voxelization"
+	 */
+	public static Img< BitType > voxelize( Mesh mesh, Dimensions dims )
+	{
+		Img< BitType > outImg = Util.getSuitableImgFactory(dims , new BitType() ).create(dims.dimensionsAsLongArray());
 		voxelize( mesh, outImg );
 		return outImg;
 	}
 
+	/**
+	 * Voxelizes {@code mesh}
+	 *
+	 * @param mesh the input {@link Mesh}
+	 * @param out an output buffer in which the voxelization will be stored (container)
+	 * @implNote op names="geom.voxelization"
+	 */
 	public static < B extends BooleanType< B > > void voxelize( Mesh mesh, RandomAccessibleInterval< B > out )
 	{
 		final long[] dims = out.dimensionsAsLongArray();

--- a/src/main/java/net/imglib2/mesh/alg/Voxelization.java
+++ b/src/main/java/net/imglib2/mesh/alg/Voxelization.java
@@ -1,0 +1,403 @@
+/*
+ * #%L
+ * 3D mesh structures for ImgLib2-related projects.
+ * %%
+ * Copyright (C) 2016 - 2023 ImgLib2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.mesh.alg;
+
+import net.imglib2.FinalDimensions;
+import net.imglib2.RandomAccess;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.RealLocalizable;
+import net.imglib2.RealPoint;
+import net.imglib2.img.Img;
+import net.imglib2.mesh.Mesh;
+import net.imglib2.mesh.Triangle;
+import net.imglib2.mesh.Vertices;
+import net.imglib2.type.BooleanType;
+import net.imglib2.type.logic.BitType;
+
+import net.imglib2.util.Util;
+import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
+
+/**
+ * This is a voxelizer that produces a binary image with values filled in along the surface of the mesh.
+ * <p>
+ * Thanks to Tomas Möller for sharing
+ * <a href="https://fileadmin.cs.lth.se/cs/Personal/Tomas_Akenine-Moller/code/tribox.txt">his public domain code</a>.
+ * </p>
+ * 
+ * @author Kyle Harrington
+ */
+public final class Voxelization
+{
+
+	private static final double EPSILON = 1e-6;
+
+	private Voxelization()
+	{
+		// NB: Prevent instantiation of utility class.
+	}
+
+	public static Img< BitType > voxelize( Mesh mesh, int width, int height, int depth )
+	{
+		Img< BitType > outImg = Util.getSuitableImgFactory( new FinalDimensions( width, height, depth ), new BitType() ).create( width, height, depth );
+		voxelize( mesh, outImg );
+		return outImg;
+	}
+
+	public static < B extends BooleanType< B > > void voxelize( Mesh mesh, RandomAccessibleInterval< B > out )
+	{
+		final long[] dims = out.dimensionsAsLongArray();
+
+		Vertices verts = mesh.vertices();
+		RealPoint minPoint = new RealPoint(3);
+		RealPoint maxPoint = new RealPoint(3);
+
+		// Initialize minPoint and maxPoint with the first vertex
+		minPoint.setPosition(verts.iterator().next());
+		maxPoint.setPosition(verts.iterator().next());
+
+		// Calculate min and max with padding
+		double[] padding = {0.5, 0.5, 0.5};
+		for (RealLocalizable v : verts) {
+			for (int d = 0; d < 3; d++) {
+				if (v.getDoublePosition(d) < minPoint.getDoublePosition(d)) {
+					minPoint.setPosition(v.getDoublePosition(d) - padding[d], d);
+				}
+				if (v.getDoublePosition(d) > maxPoint.getDoublePosition(d)) {
+					maxPoint.setPosition(v.getDoublePosition(d) + padding[d], d);
+				}
+			}
+		}
+
+		// Calculate dimPoint and step sizes
+		double[] dimPoint = new double[3];
+		double[] stepSizes = new double[3];
+		double[] voxelHalfsize = new double[3];
+		for (int d = 0; d < 3; d++) {
+			dimPoint[d] = maxPoint.getDoublePosition(d) - minPoint.getDoublePosition(d);
+			stepSizes[d] = dimPoint[d] / dims[d];
+			voxelHalfsize[d] = stepSizes[d] / 2.0;
+		}
+
+		for (final Triangle tri : mesh.triangles()) {
+			Vector3D v1 = new Vector3D(tri.v0x(), tri.v0y(), tri.v0z());
+			Vector3D v2 = new Vector3D(tri.v1x(), tri.v1y(), tri.v1z());
+			Vector3D v3 = new Vector3D(tri.v2x(), tri.v2y(), tri.v2z());
+
+			double[] minSubBoundary = {
+					Math.min(v1.getX(), Math.min(v2.getX(), v3.getX())) - minPoint.getDoublePosition(0),
+					Math.min(v1.getY(), Math.min(v2.getY(), v3.getY())) - minPoint.getDoublePosition(1),
+					Math.min(v1.getZ(), Math.min(v2.getZ(), v3.getZ())) - minPoint.getDoublePosition(2)
+			};
+
+			double[] maxSubBoundary = {
+					Math.max(v1.getX(), Math.max(v2.getX(), v3.getX())) - minPoint.getDoublePosition(0),
+					Math.max(v1.getY(), Math.max(v2.getY(), v3.getY())) - minPoint.getDoublePosition(1),
+					Math.max(v1.getZ(), Math.max(v2.getZ(), v3.getZ())) - minPoint.getDoublePosition(2)
+			};
+
+			int[][] indicesRange = new int[3][2];
+			for (int d = 0; d < 3; d++) {
+				indicesRange[d][0] = (int) Math.max(0, Math.floor(minSubBoundary[d] / stepSizes[d]));
+				indicesRange[d][1] = (int) Math.min(dims[d], Math.ceil(maxSubBoundary[d] / stepSizes[d]) + 1);
+			}
+
+			double[][] corners = {
+					{-0.5, -0.5, -0.5}, {0.5, -0.5, -0.5}, {-0.5, 0.5, -0.5}, {0.5, 0.5, -0.5},
+					{-0.5, -0.5, 0.5}, {0.5, -0.5, 0.5}, {-0.5, 0.5, 0.5}, {0.5, 0.5, 0.5}
+			};
+
+			RandomAccess< B > ra = out.randomAccess();
+			for (int i = indicesRange[0][0]; i < indicesRange[0][1]; i++) {
+				for (int j = indicesRange[1][0]; j < indicesRange[1][1]; j++) {
+					for (int k = indicesRange[2][0]; k < indicesRange[2][1]; k++) {
+						ra.setPosition(new int[]{i, j, k});
+						if (!ra.get().get()) {
+							boolean intersected = false;
+							double[] voxelCenter = {i * stepSizes[0], j * stepSizes[1], k * stepSizes[2]};
+							for (double[] corner : corners) {
+								double[] shiftedCenter = new double[3];
+								for (int d = 0; d < 3; d++) {
+									shiftedCenter[d] = voxelCenter[d] + corner[d] * voxelHalfsize[d];
+								}
+								if (triBoxOverlap(shiftedCenter, voxelHalfsize, v1, v2, v3) == 1) {
+									intersected = true;
+									break;
+								}
+							}
+							if (intersected) {
+								ra.get().set(true);
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private static double findMin(double x0, double x1, double x2) {
+		return Math.min(Math.min(x0, x1), x2);
+	}
+
+	private static double findMax(double x0, double x1, double x2) {
+		return Math.max(Math.max(x0, x1), x2);
+	}
+
+	private static double dotArray(double[] v1, double[] v2) {
+		return v1[0] * v2[0] + v1[1] * v2[1] + v1[2] * v2[2];
+	}
+
+	private static int planeBoxOverlap(double[] normalArray, double[] vertArray, double[] maxboxArray) {
+		double[] vminArray = new double[3];
+		double[] vmaxArray = new double[3];
+		for (int q = 0; q <= 2; q++) {
+			double v = vertArray[q];
+			if (normalArray[q] > 0.0F) {
+				vminArray[q] = (-maxboxArray[q] - v);
+				maxboxArray[q] -= v;
+			} else {
+				maxboxArray[q] -= v;
+				vmaxArray[q] = (-maxboxArray[q] - v);
+			}
+		}
+		if (dotArray(normalArray, vminArray) > 0.0F) {
+			return 0;
+		}
+		if (dotArray(normalArray, vmaxArray) >= 0.0F) {
+			return 1;
+		}
+		return 0;
+	}
+
+	private static int axisTest_x01(double e0, double e02, double fez, double fey, double[] v0, double[] v1, double[] v2,
+			double[] boxhalfsize) {
+		double p0 = e0 * v0[1] - e02 * v0[2];
+		double p2 = e0 * v2[1] - e02 * v2[2];
+		double max;
+		double min;
+
+		if (p0 < p2) {
+			min = p0;
+			max = p2;
+		} else {
+			min = p2;
+			max = p0;
+		}
+		double rad = fez * boxhalfsize[1] + fey * boxhalfsize[2];
+		if ((min > rad) || (max < -rad)) {
+			return 0;
+		}
+		return 1;
+	}
+
+	private static int axisTest_x2(double a, double b, double fa, double fb, double[] v0, double[] v1, double[] v2,
+			double[] boxhalfsize) {
+		double p0 = a * v0[1] - b * v0[2];
+		double p1 = a * v1[1] - b * v1[2];
+		double max;
+		double min;
+
+		if (p0 < p1) {
+			min = p0;
+			max = p1;
+		} else {
+			min = p1;
+			max = p0;
+		}
+		double rad = fa * boxhalfsize[1] + fb * boxhalfsize[2];
+		if ((min > rad) || (max < -rad)) {
+			return 0;
+		}
+		return 1;
+	}
+
+	private static int axisTest_y02(double a, double b, double fa, double fb, double[] v0, double[] v1, double[] v2,
+			double[] boxhalfsize) {
+		double p0 = -a * v0[0] + b * v0[2];
+		double p2 = -a * v2[0] + b * v2[2];
+		double max;
+		double min;
+
+		if (p0 < p2) {
+			min = p0;
+			max = p2;
+		} else {
+			min = p2;
+			max = p0;
+		}
+		double rad = fa * boxhalfsize[0] + fb * boxhalfsize[2];
+		if ((min > rad) || (max < -rad)) {
+			return 0;
+		}
+		return 1;
+	}
+
+	private static int axisTest_y1(double a, double b, double fa, double fb, double[] v0, double[] v1, double[] v2,
+			double[] boxhalfsize) {
+		double p0 = -a * v0[0] + b * v0[2];
+		double p1 = -a * v1[0] + b * v1[2];
+		double max;
+		double min;
+
+		if (p0 < p1) {
+			min = p0;
+			max = p1;
+		} else {
+			min = p1;
+			max = p0;
+		}
+		double rad = fa * boxhalfsize[0] + fb * boxhalfsize[2];
+		if ((min > rad) || (max < -rad)) {
+			return 0;
+		}
+		return 1;
+	}
+
+	private static int axisTest_z12(double a, double b, double fa, double fb, double[] v0, double[] v1, double[] v2,
+			double[] boxhalfsize) {
+		double p1 = a * v1[0] - b * v1[1];
+		double p2 = a * v2[0] - b * v2[1];
+		double max;
+		double min;
+
+		if (p2 < p1) {
+			min = p2;
+			max = p1;
+		} else {
+			min = p1;
+			max = p2;
+		}
+		double rad = fa * boxhalfsize[0] + fb * boxhalfsize[1];
+		if ((min > rad) || (max < -rad)) {
+			return 0;
+		}
+		return 1;
+	}
+
+	private static int axisTest_z0(double a, double b, double fa, double fb, double[] v0, double[] v1, double[] v2,
+			double[] boxhalfsize) {
+		double p0 = a * v0[0] - b * v0[1];
+		double p1 = a * v1[0] - b * v1[1];
+		double max;
+		double min;
+
+		if (p0 < p1) {
+			min = p0;
+			max = p1;
+		} else {
+			min = p1;
+			max = p0;
+		}
+		double rad = fa * boxhalfsize[0] + fb * boxhalfsize[1];
+		if ((min > rad) || (max < -rad)) {
+			return 0;
+		}
+		return 1;
+	}
+
+	private static void sub(double[] v0, double[] vert1, double[] boxcenter) {
+		vert1[0] -= boxcenter[0];
+		vert1[1] -= boxcenter[1];
+		vert1[2] -= boxcenter[2];
+	}
+
+	private static void cross(double[] dest, double[] v1, double[] v2) {
+		dest[0] = (v1[1] * v2[2] - v1[2] * v2[1]);
+		dest[1] = (v1[2] * v2[0] - v1[0] * v2[2]);
+		dest[2] = (v1[0] * v2[1] - v1[1] * v2[0]);
+	}
+
+	private static int triBoxOverlap(double[] boxcenter, double[] boxhalfsize, Vector3D pf1, Vector3D pf2, Vector3D pf3)
+	{
+		double[] vert1 = pf1.toArray();
+		double[] vert2 = pf2.toArray();
+		double[] vert3 = pf3.toArray();
+
+		double[] v0 = new double[3];
+		double[] v1 = new double[3];
+		double[] v2 = new double[3];
+
+		double[] normal = new double[3];
+		double[] e0 = new double[3];
+		double[] e1 = new double[3];
+		double[] e2 = new double[3];
+
+		sub(v0, vert1, boxcenter);
+		sub(v1, vert2, boxcenter);
+		sub(v2, vert3, boxcenter);
+
+		sub(e0, v1, v0);
+		sub(e1, v2, v1);
+		sub(e2, v0, v2);
+
+		double fex = Math.abs(e0[0]);
+		double fey = Math.abs(e0[1]);
+		double fez = Math.abs(e0[2]);
+
+		axisTest_x01(e0[2], e0[1], fez, fey, v0, v1, v2, boxhalfsize);
+		axisTest_y02(e0[2], e0[0], fez, fex, v0, v1, v2, boxhalfsize);
+		axisTest_z12(e0[1], e0[0], fey, fex, v0, v1, v2, boxhalfsize);
+
+		fex = Math.abs(e1[0]);
+		fey = Math.abs(e1[1]);
+		fez = Math.abs(e1[2]);
+
+		axisTest_x01(e1[2], e1[1], fez, fey, v0, v1, v2, boxhalfsize);
+		axisTest_y02(e1[2], e1[0], fez, fex, v0, v1, v2, boxhalfsize);
+		axisTest_z0(e1[1], e1[0], fey, fex, v0, v1, v2, boxhalfsize);
+
+		fex = Math.abs(e2[0]);
+		fey = Math.abs(e2[1]);
+		fez = Math.abs(e2[2]);
+
+		axisTest_x2(e2[2], e2[1], fez, fey, v0, v1, v2, boxhalfsize);
+		axisTest_y1(e2[2], e2[0], fez, fex, v0, v1, v2, boxhalfsize);
+		axisTest_z12(e2[1], e2[0], fey, fex, v0, v1, v2, boxhalfsize);
+
+		double min = findMin(v0[0], v1[0], v2[0]);
+		double max = findMax(v0[0], v1[0], v2[0]);
+		if ((min > boxhalfsize[0]) || (max < -boxhalfsize[0])) {
+			return 0;
+		}
+		min = findMin(v0[1], v1[1], v2[1]);
+		max = findMax(v0[1], v1[1], v2[1]);
+		if ((min > boxhalfsize[1]) || (max < -boxhalfsize[1])) {
+			return 0;
+		}
+		min = findMin(v0[2], v1[2], v2[2]);
+		max = findMax(v0[2], v1[2], v2[2]);
+		if ((min > boxhalfsize[2]) || (max < -boxhalfsize[2])) {
+			return 0;
+		}
+		cross(normal, e0, e1);
+		if (planeBoxOverlap(normal, v0, boxhalfsize) != 1) {
+			return 0;
+		}
+		return 1;
+	}
+}

--- a/src/test/java/net/imglib2/mesh/MeshStatsTest.java
+++ b/src/test/java/net/imglib2/mesh/MeshStatsTest.java
@@ -88,6 +88,60 @@ public class MeshStatsTest
 	}
 
 	@Test
+	public void elongation()
+	{
+		// The below code creates an octahedron, with all points on an axis.
+		// The octahedron is stretched on the x-axis, such that the
+		// elongation on the x-z and x-y principal planes is 0.5
+		// and the elongation on the y-z plane is 0
+		Mesh mesh2 = new NaiveDoubleMesh();
+		mesh2.vertices().add(2, 0, 0);
+		mesh2.vertices().add(0, 1, 0);
+		mesh2.vertices().add(0, 0, 1);
+		mesh2.vertices().add(-2, 0, 0);
+		mesh2.vertices().add(0, -1, 0);
+		mesh2.vertices().add(0, 0, -1);
+		mesh2.triangles().add(0, 2, 1);
+		mesh2.triangles().add(4, 2, 0);
+		mesh2.triangles().add(3, 2, 4);
+		mesh2.triangles().add(1, 2, 3);
+		mesh2.triangles().add(5, 0, 1);
+		mesh2.triangles().add(5, 4, 0);
+		mesh2.triangles().add(5, 3, 4);
+		mesh2.triangles().add(5, 1, 3);
+		final double[] expected = { //
+				0.0, 0.5, 0.5, //
+				0.5, 0.0, 0.0, //
+				0.5, 0.0, 0.0 //
+		};
+		final RealMatrix actual = MeshStats.elongation(mesh2);
+		actual.walkInRowOrder( new RealMatrixChangingVisitor()
+		{
+
+			private int i = 0;
+
+			@Override
+			public double visit( final int row, final int column, final double value )
+			{
+				final double e = expected[ i++ ];
+				assertEquals( "Incorrect inertia tensor value returned for row " + row + " and column " + column,
+						e, value, EPSILON );
+				return 0;
+			}
+
+			@Override
+			public void start( final int rows, final int columns, final int startRow, final int endRow, final int startColumn, final int endColumn )
+			{}
+
+			@Override
+			public double end()
+			{
+				return 0;
+			}
+		} );
+	}
+
+	@Test
 	public void inertiaTensor()
 	{
 		// Computed with MATLAB.
@@ -166,6 +220,15 @@ public class MeshStatsTest
 		// ground truth computed with matlab
 		final double expected = 0.845648604269294;
 		assertEquals( "Incorrect solidity returned.", expected, actual, EPSILON );
+	}
+
+	@Test
+	public void spareness()
+	{
+		final double actual = MeshStats.spareness(mesh);
+		// ground truth computed with matlab
+		final double expected = 0.9838757743034947;
+		assertEquals( "Incorrect sphericity returned.", expected, actual, EPSILON );
 	}
 
 	@Test

--- a/src/test/java/net/imglib2/mesh/MeshesTest.java
+++ b/src/test/java/net/imglib2/mesh/MeshesTest.java
@@ -28,9 +28,6 @@
  */
 package net.imglib2.mesh;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import javax.imageio.ImageIO;
 import javax.imageio.ImageReader;
 import java.awt.image.BufferedImage;
@@ -39,11 +36,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import gnu.trove.list.array.TLongArrayList;
 import org.apache.commons.math3.geometry.euclidean.threed.Vector3D;
@@ -66,6 +59,8 @@ import net.imglib2.type.numeric.integer.IntType;
 import net.imglib2.type.numeric.real.FloatType;
 import net.imglib2.util.Fraction;
 import net.imglib2.view.RandomAccessibleIntervalCursor;
+
+import static org.junit.Assert.*;
 
 public class MeshesTest
 {
@@ -159,6 +154,34 @@ public class MeshesTest
 			assertEquals( expected.v2z(), actual.v2z(), EPSILON );
 		}
 		assertTrue( !expectedFacets.hasNext() && !actualFacets.hasNext() );
+	}
+
+	@Test
+	public void testBoundingBoxMesh() {
+		final Mesh mesh = new NaiveDoubleMesh();
+		// Create a pyramid between the points
+		long bbl = mesh.vertices().add(0, 0, 0);
+		long bbr = mesh.vertices().add(1, 0, 0);
+		long bfl = mesh.vertices().add(0, 1, 0);
+		long t = mesh.vertices().add(0, 0, 1);
+		mesh.triangles().add(bbl, bfl, bbr);
+		mesh.triangles().add(t, bbr, bfl);
+		mesh.triangles().add(t, bbl, bbr);
+		mesh.triangles().add(t, bfl, bbl);
+
+		// Get the bounding box
+		final Mesh bounding = Meshes.boundingBoxMesh(mesh);
+		// Assert expected points and number of vertices
+		Iterator<Vertex> itr = bounding.vertices().iterator();
+		assertArrayEquals(new double[] {0, 0, 0}, itr.next().positionAsDoubleArray(), 0);
+		assertArrayEquals(new double[] {1, 0, 0}, itr.next().positionAsDoubleArray(), 0);
+		assertArrayEquals(new double[] {0, 1, 0}, itr.next().positionAsDoubleArray(), 0);
+		assertArrayEquals(new double[] {1, 1, 0}, itr.next().positionAsDoubleArray(), 0);
+		assertArrayEquals(new double[] {0, 0, 1}, itr.next().positionAsDoubleArray(), 0);
+		assertArrayEquals(new double[] {1, 0, 1}, itr.next().positionAsDoubleArray(), 0);
+		assertArrayEquals(new double[] {0, 1, 1}, itr.next().positionAsDoubleArray(), 0);
+		assertArrayEquals(new double[] {1, 1, 1}, itr.next().positionAsDoubleArray(), 0);
+		assertFalse(itr.hasNext());
 	}
 
 	private static Mesh createMeshWithNoise()

--- a/src/test/java/net/imglib2/mesh/alg/VoxelizationTest.java
+++ b/src/test/java/net/imglib2/mesh/alg/VoxelizationTest.java
@@ -1,0 +1,142 @@
+/*-
+ * #%L
+ * 3D mesh structures for ImgLib2-related projects.
+ * %%
+ * Copyright (C) 2016 - 2023 ImgLib2 developers.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package net.imglib2.mesh.alg;
+
+import net.imglib2.Cursor;
+import net.imglib2.Point;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.fill.FloodFill;
+import net.imglib2.algorithm.neighborhood.RectangleShape;
+import net.imglib2.img.Img;
+import net.imglib2.img.array.ArrayImgs;
+import net.imglib2.loops.LoopBuilder;
+import net.imglib2.mesh.Mesh;
+import net.imglib2.type.logic.BitType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests {@link Voxelization}.
+ *
+ * @author Kyle Harrington
+ * @author Curtis Rueden
+ */
+public class VoxelizationTest
+{
+
+	@Test
+	public void voxelization3D() {
+		final int radius = 50; // a balance between speed and accuracy
+		final int w, h, d;
+		w = h = d = 2 * radius;
+		RandomAccessibleInterval<BitType> sphere = generateSphere(radius);
+		final Mesh mesh = MarchingCubesBooleanType.calculate(sphere);
+
+		// The mesh is good by now, let's check the voxelization
+		Img< BitType > voxelization = Voxelization.voxelize(mesh, w, h, d);
+
+		// Flood fill (ops implementation starts from borders)
+		//RandomAccessibleInterval< BitType > filledVoxelization = ops.run(DefaultFillHoles.class, voxelization);
+		Img< BitType > filledVoxelization = voxelization.copy();
+		FloodFill.fill(
+			filledVoxelization, // source
+			filledVoxelization, // target
+			new Point( radius, radius ,radius ), // seed
+			new BitType( true ), // fillLabel
+			new RectangleShape( 1, false ) );
+
+		// Comparison
+		long diff = compareImages(sphere, filledVoxelization);
+
+		// radius |  samples | deviations | area (4πr²) | dev-to-area
+		// -------|----------|------------|-------------|------------
+		//     10 |     4166 |       1494 |      1256.6 | 1.188922489
+		//     20 |    33398 |       6690 |      5026.4 | 1.330972465
+		//     30 |   113078 |      15406 |     11309.4 | 1.362229650
+		//     40 |   267758 |      27850 |     20105.6 | 1.385186217
+		//     50 |   523302 |      43710 |     31415.0 | 1.391373548
+		//     60 |   904086 |      63102 |     45237.6 | 1.394901586
+		//     70 |  1436382 |      86178 |     61573.4 | 1.399597878
+		//     80 |  2143638 |     112690 |     80422.4 | 1.401226524
+		//     90 |  3053614 |     143070 |    101784.6 | 1.405615388
+		//    100 |  4187854 |     176886 |    125660.0 | 1.407655579
+		//    110 |  5574718 |     213954 |    152048.6 | 1.407142190
+		//    120 |  7236574 |     255058 |    180950.4 | 1.409546483
+		//    130 |  9201622 |     299470 |    212365.4 | 1.410163803
+		//    140 | 11492078 |     347286 |    246293.6 | 1.410048820
+		//    150 | 14137634 |     399078 |    282735.0 | 1.411491326
+		final double area = 4 * Math.PI * radius * radius;
+		final double ratio = diff / area;
+		final String statSuffix = String.format(" (diff=%d, area=%f, ratio=%f).", diff, area, ratio);
+		assertTrue("Voxelization differs from the original image too much" + statSuffix, ratio < 1.412);
+		assertTrue("Voxelization matches the original image suspiciously well" + statSuffix, ratio > 1.18);
+	}
+
+	/**
+	 * Creates a 3D binary image of a sphere.
+	 *
+	 * @param r The radius of the sphere.
+	 * @return A RandomAccessibleInterval representing the sphere.
+	 */
+	private RandomAccessibleInterval<BitType> generateSphere(int r) {
+		long[] dims = new long[] {2*r, 2*r, 2*r}; // Dimensions of the bounding box of the sphere
+		Img<BitType> sphereImg = ArrayImgs.bits(dims);
+
+		Cursor<BitType> cursor = sphereImg.localizingCursor();
+
+		// Center of the sphere
+		int cx = r;
+		int cy = r;
+		int cz = r;
+
+		while (cursor.hasNext()) {
+			cursor.fwd();
+			int x = cursor.getIntPosition(0) - cx;
+			int y = cursor.getIntPosition(1) - cy;
+			int z = cursor.getIntPosition(2) - cz;
+
+			if (x * x + y * y + z * z <= r * r) {
+				cursor.get().set(true);
+			}
+		}
+
+		return sphereImg;
+	}
+
+	private long compareImages( RandomAccessibleInterval<BitType> img1, RandomAccessibleInterval<BitType> img2 )
+	{
+		final long[] diff = { 0 };
+		LoopBuilder.setImages( img1, img2 ).forEachPixel( ( a, b ) ->
+		{
+			if ( !a.valueEquals( b ) ) diff[ 0 ]++;
+		});
+		return diff[ 0 ];
+	}
+}

--- a/src/test/java/net/imglib2/mesh/alg/hull/QuickHull3DTest.java
+++ b/src/test/java/net/imglib2/mesh/alg/hull/QuickHull3DTest.java
@@ -61,6 +61,7 @@ public class QuickHull3DTest
 
 		final NaiveDoubleMesh convexHull = ConvexHull.calculate( df );
 		final double epsilon = ConvexHull.lastEpsilon();
+		assertEquals(epsilon, ConvexHull.calculateEpsilon(convexHull), 0);
 		assertEquals( 175, convexHull.vertices().size() );
 		assertConvex( convexHull, epsilon );
 	}
@@ -76,6 +77,7 @@ public class QuickHull3DTest
 
 		final NaiveDoubleMesh convexHull = ConvexHull.calculate( df );
 		final double epsilon = ConvexHull.lastEpsilon();
+		assertEquals(epsilon, ConvexHull.calculateEpsilon(convexHull), 0);
 		assertEquals( 4, convexHull.vertices().size() );
 		assertConvex( convexHull, epsilon );
 	}
@@ -93,6 +95,7 @@ public class QuickHull3DTest
 
 		final NaiveDoubleMesh convexHull = ConvexHull.calculate( df );
 		final double epsilon = ConvexHull.lastEpsilon();
+		assertEquals(epsilon, ConvexHull.calculateEpsilon(convexHull), 0);
 		assertEquals( 5, convexHull.vertices().size() );
 		assertConvex( convexHull, epsilon );
 	}
@@ -119,6 +122,7 @@ public class QuickHull3DTest
 
 		final NaiveDoubleMesh convexHull = ConvexHull.calculate( df );
 		final double epsilon = ConvexHull.lastEpsilon();
+		assertEquals(epsilon, ConvexHull.calculateEpsilon(convexHull), 0);
 		assertEquals( 12, convexHull.vertices().size() );
 		assertConvex( convexHull, epsilon );
 	}
@@ -172,6 +176,7 @@ public class QuickHull3DTest
 
 		final NaiveDoubleMesh convexHull = ConvexHull.calculate( df );
 		final double epsilon = ConvexHull.lastEpsilon();
+		assertEquals(epsilon, ConvexHull.calculateEpsilon(convexHull), 0);
 		assertEquals( 20, convexHull.vertices().size() );
 		assertConvex( convexHull, epsilon );
 	}


### PR DESCRIPTION
This WIP PR intends to "opify" the static functionality within the project, and is divided into two subtasks:
1. Declare all op-like algorithms as Ops using the SciJava Ops Indexer
2. Migrate all Ops operating on `Mesh`es from [scijava-ops-image](https://github.com/scijava/scijava/tree/main/scijava-ops-image) to here.

I've additionally filed issues for, or just outright added, functionality that was declared to work in scijava-ops-image/ImageJ Ops but was not functional:
  * Added `Meshes.boundingBoxMesh` that creates a bounding box `Mesh` from another `Mesh`.
  * Filed #8 and #9

**Points of discussion**:
* I find the `geom.mainElongation` and `geom.medianElongation` Ops to have confusing names, as I could find no literature that named these properties. My understanding is that `geom.mainElongation` measures the elongation of a cross-section ellipse, where the section is perpendicular to the two larger semi-axes, while `geom.medianElongation` does the same but with the two smaller semi-axes. @tibuch is this correct? At a minimum I want to document this, but better would be to come up with better names so we can alias the Op.