### PR TITLE
Addition of getType() API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>37.0.0</version>
+		<version>38.0.1</version>
 		<relativePath />
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,8 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
+		<imglib2.version>7.1.0</imglib2.version>
+		<imglib2-roi.version>0.15.0</imglib2-roi.version>
 		<imageio-tiff.version>3.9.4</imageio-tiff.version>
 	</properties>
 


### PR DESCRIPTION
Bump to latest pom-scijava and bump imglib2 versions.

A binary incompatibility was introduced in ImgLib2 which requires re-compilation of imglib2-mesh:

`Views.flatIterable(...)` returns `RandomAccessibleInterval` instead of `IterableInterval`. The reasoning is that `RandomAccessibleInterval` extends `IterableInterval` (since imglib2-7.0.0), and there is no reason to strip the RandomAccess part from the flatIterable result.
