### PR TITLE
change RemoveDuplicateVertices and calculateNormals function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
 			<url>https://imagej.net/people/frauzufall</url>
 			<properties><id>frauzufall</id></properties>
 		</contributor>
+		<contributor>
+			<name>Eugene Katrukha</name>
+			<url>https://imagej.net/people/ekatrukha</url>
+			<properties><id>ekatrukha</id></properties>
+		</contributor>
 	</contributors>
 
 	<mailingLists>

--- a/src/main/java/net/imglib2/mesh/Meshes.java
+++ b/src/main/java/net/imglib2/mesh/Meshes.java
@@ -215,6 +215,8 @@ public class Meshes
 		final HashMap< Long, float[] > vNormals = new HashMap<>();
 		//vertex cumulative normal
 		float[] cumNormal;
+		//vertex index
+		long idx;
 		
 		for ( final Triangle tri : src.triangles() )
 		{
@@ -245,16 +247,28 @@ public class Meshes
 			final float nz = v10x * v20y - v10y * v20x;
 			
 			//cumulative, triangle area weighted normals per vertex.
-			for ( final long idx : new long[] { tri.vertex0(), tri.vertex1(), tri.vertex2() } )
-			{
-				cumNormal = vNormals.getOrDefault( idx, new float[] { 0, 0, 0 } );
-				cumNormal[ 0 ] += nx;
-				cumNormal[ 1 ] += ny;
-				cumNormal[ 2 ] += nz;
-				vNormals.put( idx, cumNormal );
-			}
+			idx = tri.vertex0();
+			cumNormal = vNormals.getOrDefault(idx, new float[] { 0, 0, 0 });
+			cumNormal[0] += nx;
+			cumNormal[1] += ny;
+			cumNormal[2] += nz;
+			vNormals.put(idx, cumNormal);
+
+			idx = tri.vertex1();
+			cumNormal = vNormals.getOrDefault(idx, new float[] { 0, 0, 0 });
+			cumNormal[0] += nx;
+			cumNormal[1] += ny;
+			cumNormal[2] += nz;
+			vNormals.put(idx, cumNormal);
+
+			idx = tri.vertex2();
+			cumNormal = vNormals.getOrDefault(idx, new float[] { 0, 0, 0 });
+			cumNormal[0] += nx;
+			cumNormal[1] += ny;
+			cumNormal[2] += nz;
+			vNormals.put(idx, cumNormal);
 			
-			final float nmag = ( float ) Math.sqrt( Math.pow( nx, 2 ) + Math.pow( ny, 2 ) + Math.pow( nz, 2 ) );
+			final float nmag = ( float ) Math.sqrt( nx * nx + ny * ny + nz * nz );
 			triNormals.put( tri.index(), new float[] { nx / nmag, ny / nmag, nz / nmag } );
 		}
 
@@ -267,7 +281,7 @@ public class Meshes
 		{
 			final long srcIndex = v.index();
 			vNormal = vNormals.get( v.index() );
-			vNormalMag = Math.sqrt( Math.pow( vNormal[ 0 ], 2 ) + Math.pow( vNormal[ 1 ], 2 ) + Math.pow( vNormal[ 2 ], 2 ) );
+			vNormalMag = Math.sqrt( vNormal[ 0 ] * vNormal[ 0 ] + vNormal[ 1 ] * vNormal[ 1 ] + vNormal[ 2 ] * vNormal[ 2 ] );
 			final long destIndex = dest.vertices().add( //
 					v.x(), v.y(), v.z(), //
 					vNormal[ 0 ] / vNormalMag, vNormal[ 1 ] / vNormalMag, vNormal[ 2 ] / vNormalMag, //
@@ -465,8 +479,8 @@ public class Meshes
 	public static void translateScale( final Mesh mesh, final double[] translate, final double[] scale )
 	{
 		final Vertices vertices = mesh.vertices();
-		final long nv = vertices.size();
-		for ( long i = 0; i < nv; i++ )
+		final long nVertices = vertices.sizel();
+		for ( long i = 0; i < nVertices; i++ )
 		{
 			final double x = ( translate[ 0 ] + vertices.x( i ) ) * scale[ 0 ];
 			final double y = ( translate[ 1 ] + vertices.y( i ) ) * scale[ 1 ];

--- a/src/main/java/net/imglib2/mesh/Meshes.java
+++ b/src/main/java/net/imglib2/mesh/Meshes.java
@@ -328,7 +328,8 @@ public class Meshes
 	/**
 	 * Creates a new mesh from a given mesh without any duplicate vertices.
 	 * Normals and uv coordinates will be ignored and not added to the output
-	 * mesh.
+	 * mesh. The number of the output triangles is equal or less than the input,
+	 * since degenerate (collapsed) triangles are omitted.
 	 *
 	 * @param mesh
 	 *            Source mesh

--- a/src/main/java/net/imglib2/mesh/alg/RemoveDuplicateVertices.java
+++ b/src/main/java/net/imglib2/mesh/alg/RemoveDuplicateVertices.java
@@ -68,14 +68,14 @@ public class RemoveDuplicateVertices
 				trianglesCount++;
 			}
 		}
-		final BufferMesh res = new BufferMesh( vertices.size(), triangles.length );
+		final BufferMesh res = new BufferMesh( vertices.size(), trianglesCount );
 		vertices.values().forEach( vertex -> {
 			res.vertices().add( vertex.point.getFloatPosition( 0 ), vertex.point.getFloatPosition( 1 ), vertex.point.getFloatPosition( 2 ) );
 		} );
 
-		for ( final int[] triangle : triangles )
+		for ( int i = 0; i < trianglesCount; i++ )
 		{
-			res.triangles().add( triangle[ 0 ], triangle[ 1 ], triangle[ 2 ] );
+			res.triangles().add( triangles[ i ][ 0 ], triangles[ i ][ 1 ], triangles[ i ][ 2 ] );
 		}
 		return res;
 	}

--- a/src/main/java/net/imglib2/mesh/alg/RemoveDuplicateVertices.java
+++ b/src/main/java/net/imglib2/mesh/alg/RemoveDuplicateVertices.java
@@ -39,6 +39,7 @@ import net.imglib2.mesh.impl.nio.BufferMesh;
 
 /**
  * @author Deborah Schmidt
+ * @author Eugene Katrukha
  */
 public class RemoveDuplicateVertices
 {
@@ -54,10 +55,18 @@ public class RemoveDuplicateVertices
 			final RealPoint p1 = new RealPoint( triangle.v0x(), triangle.v0y(), triangle.v0z() );
 			final RealPoint p2 = new RealPoint( triangle.v1x(), triangle.v1y(), triangle.v1z() );
 			final RealPoint p3 = new RealPoint( triangle.v2x(), triangle.v2y(), triangle.v2z() );
-			triangles[ trianglesCount ][ 0 ] = getVertex( vertices, p1, precision );
-			triangles[ trianglesCount ][ 1 ] = getVertex( vertices, p2, precision );
-			triangles[ trianglesCount ][ 2 ] = getVertex( vertices, p3, precision );
-			trianglesCount++;
+			
+			final int v1 = getVertex( vertices, p1, precision );
+			final int v2 = getVertex( vertices, p2, precision );
+			final int v3 = getVertex( vertices, p3, precision );
+			
+			if( v1 != v2 && v1 != v3 && v2 != v3 )
+			{
+				triangles[ trianglesCount ][ 0 ] = v1;
+				triangles[ trianglesCount ][ 1 ] = v2;
+				triangles[ trianglesCount ][ 2 ] = v3;
+				trianglesCount++;
+			}
 		}
 		final BufferMesh res = new BufferMesh( vertices.size(), triangles.length );
 		vertices.values().forEach( vertex -> {


### PR DESCRIPTION
This PR suggests changing two things.

First, in the `calculate` function of `RemoveDuplicateVertices` class, add a check to see if some of the triangles become degenerate.
This is done by one extra condition: do some of the triangle vertices (indices) become equal.
I.e. triangle is "collapsed", where two or three vertices coincide, resulting in zero area.
This can happen when we round up the vertices' coordinates with specified precision.

The situation can arise, for example, if the characteristic triangle size is less than the provided precision value. 
Sometimes, after marching cubes, if one rounds up with precision larger than or equal to the pixel size.  
These degenerative triangles are no problem for the rendering, but if one tries to calculate normals after (which is often the case, since the function output mesh does not have normals anymore), it is a big problem.  

(In principle, another option is possible, that all three vertices are on the same line, also zero area, not checked right now)

Second, I suggest to change `calculateNormals` function of the `Meshes` class.
The reasoning behind this is very nicely explained in [this post](https://iquilezles.org/articles/normals/).
Quick reminder, right now, the function calculates averaged vertex normals by averaging the normals of the triangles that this vertex is part of.

It is a "regular" averaging now, but it actually looks better if the normals are averaged with weights equal to the areas of the triangles.
These areas are already calculated from the cross product, so this actually eliminates one extra loop over triangles (speed up! again, check [the post](https://iquilezles.org/articles/normals/)).

Additionally, it actually handles cases of "degenerative" triangles, since in this case the normal length can be zero and there is no prior normalization, which can lead to infinity and break the cumulative normal calculation.

To illustrate it, here is a movie that has multiple renderings of the example [unperfect_sphere.stl](https://katpyxa.info/software/misc/unperfect_sphere.stl) mesh. 
This mesh has some small triangles that become degenerate after `RemoveDuplicateVertices`.


https://github.com/user-attachments/assets/93dba253-ce66-4945-856f-b956332cfa3d


From left to right
1) original mesh with multiple duplicate vertices, and normals are calculated
using the current implementation of `calculateNormals`
2) on this mesh, we first applythe  current `RemoveDuplicateVertices` (precision 1)
and then the current `calculateNormals`. Since some small triangles are degenerative,
the normals of adjacent triangles are "black", i.e. infinity.
3) on this mesh, we first apply the proposed `RemoveDuplicateVertices` (precision 1)
and then the current `calculateNormals`. Since degenerative triangles are gone,
the normals of the "leftofer" majority become "proper". But there are still some
very small "badly" oriented triangles that contribute to the vertex normals
of the larger triangles (since their weight is the same as large ones). 
4) proposed `RemoveDuplicateVertices` (precision 1) and then proposed `calculateNormals`.
The effect of small triangles on the large is negligible, since they are weighted by area.

To reproduce this issue, I used [this branch of BVB](https://github.com/UU-cellbiology/bigvolumebrowser/tree/smoothNormal), since I wanted to see rendering.
This branch depends on the proposed version of imglib2-mesh.
If you load the provided stl file to this branch, it will render option 1),
if you load it gain, option 2), etc.

If it is not enough, I can try to make an alternative and simpler test
somewhere else, let me know.

Cheers,
Eugene

[unperfect_sphere.zip](https://github.com/user-attachments/files/24614894/unperfect_sphere.zip)


